### PR TITLE
Improved figure style

### DIFF
--- a/delegation_oriented_api.md
+++ b/delegation_oriented_api.md
@@ -22,10 +22,11 @@ server-side backwards compatibility.
 
 ## Basic Flow
 
-<figure class="image">
+<figure>
   <img src="./static/delegation-api-flow.svg" alt="High-level flow diagram for delegation-oriented approach" />
-  <figcaption><center><strong>Figure.</strong> <em>High-level flow diagram for delegation-oriented approach</em></center></figcaption>
+  <figcaption><em>High-level flow diagram for delegation-oriented approach</em></figcaption>
 </figure>
+
 
 
 Notice that in this approach we are assuming that an email proxy and email
@@ -38,9 +39,9 @@ importance of recovery code and salt are discussed in the next section.
 
 **TODO**(majidvp): Explain in more details.
 
-<figure class="image">
+<figure>
   <img src="./static/delegation-api-signup-flow.svg" alt="Sign-Up Flow for a WebID enabled browser" />
-  <figcaption><center><strong>Figure.</strong> <em>Sign-Up Flow for a WebID enabled browser</em></center></figcaption>
+  <figcaption><em>Sign-Up Flow for a WebID enabled browser</em></figcaption>
 </figure>
 
 
@@ -180,14 +181,14 @@ account on RP using a new browser or platform that either:
     **IDP gets unblinded** as it learns about the user sign-in to the RP.  
 
 
-<figure class="image">
+<figure>
   <img src="./static/delegation-api-recovery-signin-flow.svg" alt="Sign-In (Recovery) Flow for a fresh WebID enabled browser" />
-  <figcaption><center><strong>Figure.</strong> <em>Sign-In (Recovery) Flow for a fresh WebID enabled browser</em></center></figcaption>
+  <figcaption><em>Sign-In (Recovery) Flow for a fresh WebID enabled browser</em></figcaption>
 </figure>
 
 
 
-<figure class="image">
+<figure>
   <img src="./static/delegation-api-recovery-legacy-flow.svg" alt="Sign-In (Recovery) Flow for legacy non-WebID enabled browser/apps" />
-  <figcaption><center><strong>Figure. </strong> <em>Sign-In (Recovery) Flow for legacy non-WebID enabled browser/apps</em></center></figcaption>
+  <figcaption><em>Sign-In (Recovery) Flow for legacy non-WebID enabled browser/apps</em></figcaption>
 </figure>

--- a/static/index.css
+++ b/static/index.css
@@ -16,10 +16,31 @@ body {
   color: #333333;
   background-color: white;
   overflow-y: hidden;
+
+  counter-reset: figures;
 }
 
 img {
   max-width: 100%;
+}
+
+figure {
+  display: flex;
+  flex-flow: column;
+  padding: 5px;
+}
+
+figcaption {
+  counter-increment: figures;
+
+  font: italic smaller sans-serif;
+  padding: 3px;
+  text-align: center;
+}
+
+figcaption:before {
+  content: 'Figure ' counter(figures) ' - ';
+  font-weight: bold;
 }
 
 .header {


### PR DESCRIPTION
Improves the figure embedding.

Instead of basic markdown image embed you can now use a figure. This will enable using a caption and automatically gives a numbered figure to the caption. See screenshot.

In vanilla GH rendering  the caption is not centered or numbered but still visible and emphasized thanks to `<em>` tag. ([example](https://github.com/majido/WebID/blob/better-figure/delegation_oriented_api.md))

```
<figure>
  <img src="./static/image.svg" alt="alt text" />
  <figcaption><em>Image caption</em></figcaption>
</figure>
```

<img width="1029" alt="Screen Shot 2020-10-09 at 2 57 01 PM" src="https://user-images.githubusercontent.com/944639/95622580-c9d0fa00-0a41-11eb-8678-7029a9b662ab.png">
