### PR TITLE
fix typo for JWT

### DIFF
--- a/HOWTO.md
+++ b/HOWTO.md
@@ -99,4 +99,4 @@ If the IdP responded to the token fetch in the previous step with a `signin_url`
 navigator.id.provide('YOUR_JWT_TOKEN_HERE');
 ```
 
-The string should contain a [JTW](https://jwt.io/).
+The string should contain a [JWT](https://jwt.io/).


### PR DESCRIPTION
s/JTW/JWT/

For IPR issue, please set "Mark as non-substantive".